### PR TITLE
fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: freckle/haskell-tag-action@v1
 
       - if: steps.tag.outputs.tag
-        run: stack upload --pvp-bounds lower debug-print
+        run: stack upload --pvp-bounds lower .
         env:
           HACKAGE_KEY: ${{ secrets.HACKAGE_UPLOAD_API_KEY }}
           STACK_YAML: stack-lts23.yaml


### PR DESCRIPTION
One day I will manage to write a release workflow that works on the first try.

Apparently in this context Stack requires a directory, not a package name.