### PR TITLE
Elide empty fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
-## [_Unreleased_](https://github.com/freckle/debug-print/compare/v0.1.0.0...main)
+## [_Unreleased_](https://github.com/freckle/debug-print/compare/v0.2.0.0...main)
 
-## [v0.1.0.0](https://github.com/freckle/nonempty-zipper/compare/v0.0.0.0...v0.1.0.0)
+## [v0.2.0.0](https://github.com/freckle/debug-print/compare/v0.2.0.0...v0.2.0.0)
+
+To reduce clutter in output, the default `Generic`-derived `ToDebugPrintRecord`
+instance now elides any field whose values is empty text, an empty list, or an
+empty object.
+
+## [v0.1.0.0](https://github.com/freckle/debug-print/compare/v0.0.0.0...v0.1.0.0)
 
 The parameter of `DebugPrintValueInt` is changed from `Int` to `Integer`.
 

--- a/README.lhs
+++ b/README.lhs
@@ -26,13 +26,15 @@ import Data.Aeson qualified as Aeson
 data Report = Report
   { milliseconds :: Int
   , errors :: [Text]
+  , fileName :: Maybe Text
   }
   deriving stock Generic
   deriving anyclass (ToDebugPrintRecord, ToDebugPrintValue)
 
 report :: Report
 report = Report{ milliseconds = 5_824
-               , errors = ["Warning! Problems."] }
+                , errors = ["Warning! Problems."]
+                , fileName = Nothing }
 ```
 
 ```haskell

--- a/debug-print.cabal
+++ b/debug-print.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.0
 -- see: https://github.com/sol/hpack
 
 name:           debug-print
-version:        0.1.0.0
+version:        0.2.0.0
 synopsis:       A structured alternative to Show
 category:       Debug
 homepage:       https://github.com/freckle/debug-print#readme
@@ -108,6 +108,35 @@ test-suite readme
     , debug-print
     , hspec
     , markdown-unlit
+    , text
+  default-language: GHC2021
+  if impl(ghc >= 9.8)
+    ghc-options: -Wno-missing-role-annotations -Wno-missing-poly-kind-signatures
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Paths_debug_print
+  autogen-modules:
+      Paths_debug_print
+  hs-source-dirs:
+      tests
+  default-extensions:
+      DefaultSignatures
+      DeriveAnyClass
+      DerivingVia
+      NoFieldSelectors
+      NoImplicitPrelude
+      NoMonomorphismRestriction
+      OverloadedStrings
+      StrictData
+  ghc-options: -Weverything -Wno-all-missed-specialisations -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-safe-haskell-mode -Wno-safe -Wno-unsafe
+  build-depends:
+      aeson-qq
+    , base <5
+    , debug-print
+    , hspec
     , text
   default-language: GHC2021
   if impl(ghc >= 9.8)

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,7 +1,13 @@
 cradle:
   stack:
-    - path: "debug-print/library"
+    - path: "./library"
       component: "debug-print:lib"
 
-    - path: "debug-print/./"
+    - path: "./internal"
+      component: "debug-print:lib:internal"
+
+    - path: "././"
       component: "debug-print:test:readme"
+
+    - path: "./tests"
+      component: "debug-print:test:spec"

--- a/internal/DebugPrint/Core.hs
+++ b/internal/DebugPrint/Core.hs
@@ -134,7 +134,11 @@ instance ToDebugPrintRecordRep f => ToDebugPrintRecordRep (C1 i f) where
   gToRecord (M1 x) = gToRecord x
 
 instance (Selector s, ToDebugPrintValueRep f) => ToDebugPrintRecordRep (S1 s f) where
-  gToRecord s1@(M1 x) = DebugPrintRecord $ Map.singleton (T.pack (selName s1)) (gToValue x)
+  gToRecord s1@(M1 x) = DebugPrintRecord $ case gToValue x of
+    DebugPrintValueText y | T.null y -> Map.empty
+    DebugPrintValueVector y | V.null y -> Map.empty
+    DebugPrintValueRecord (DebugPrintRecord y) | Map.null y -> Map.empty
+    y -> Map.singleton (T.pack (selName s1)) y
 
 ---
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: debug-print
-version: 0.1.0.0
+version: 0.2.0.0
 maintainer: Freckle Education
 category: Debug
 github: freckle/debug-print
@@ -57,6 +57,15 @@ internal-libraries:
       - vector
 
 tests:
+  spec:
+    main: Main.hs
+    source-dirs: tests
+    dependencies:
+      - aeson-qq
+      - debug-print
+      - hspec
+      - text
+
   readme:
     main: README.lhs
     ghc-options: -pgmL markdown-unlit

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Main (main) where
+
+import Prelude
+
+import Data.Aeson.QQ
+import Data.Text (Text)
+import DebugPrint
+import DebugPrint.Aeson
+import GHC.Generics (Generic)
+import Test.Hspec
+
+data Report = Report
+  { milliseconds :: Int
+  , errors :: [Text]
+  , fileName :: Maybe Text
+  }
+  deriving stock (Generic)
+  deriving anyclass (ToDebugPrintRecord, ToDebugPrintValue)
+
+data Place = Place
+  { country :: Text
+  , region :: Text
+  }
+  deriving stock (Generic)
+  deriving anyclass (ToDebugPrintRecord, ToDebugPrintValue)
+
+data Journey = Journey
+  { from :: Place
+  , to :: Place
+  }
+  deriving stock (Generic)
+  deriving anyclass (ToDebugPrintRecord, ToDebugPrintValue)
+
+main :: IO ()
+main = hspec $ do
+  describe "debugPrintValueToAeson" $ do
+    it "Omits Nothing fields" $ do
+      debugPrintValueToAeson
+        Report
+          { milliseconds = 5_824
+          , errors = ["Warning! Problems."]
+          , fileName = Nothing
+          }
+        `shouldBe` [aesonQQ| { errors: ["Warning! Problems."], milliseconds: 5824 } |]
+
+    it "Omits empty Vector fields" $ do
+      debugPrintValueToAeson
+        Report
+          { milliseconds = 0
+          , errors = []
+          , fileName = Just "records.csv"
+          }
+        `shouldBe` [aesonQQ| { fileName: ["records.csv"], milliseconds: 0 } |]
+
+    it "Omits empty Text" $ do
+      debugPrintValueToAeson
+        Place
+          { country = "USA"
+          , region = ""
+          }
+        `shouldBe` [aesonQQ| {country: "USA" } |]
+
+    it "Omits empty objects" $ do
+      debugPrintValueToAeson
+        Journey
+          { from =
+              Place
+                { country = "USA"
+                , region = ""
+                }
+          , to = Place {country = "", region = ""}
+          }
+        `shouldBe` [aesonQQ| { from: { country: "USA" } } |]


### PR DESCRIPTION
A change to the way objects are rendered. When a field value is empty text, an empty list, or an empty object, the field is omitted entirely. This just declutters the output.

The output from this package is used in golden test output files and in log metadata in `curricula-build`. This change is ultimately in support of https://app.asana.com/1/12760955038819/project/1207668999374377/task/1209914540357769 which would have us printing to golden test output files a very large record in which most of the fields are empty, which would get ugly without this change.