### PR TITLE
add instances for aeson types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Add instances for `aeson` types:
 
 Adds `Eq` and `Ord` instances for `ToDebugPrintValue` and `ToDebugPrintRecord`
 
+Add `instance ToDebugPrintValue DebugPrintRecord`
+
 ## [v0.2.0.1](https://github.com/freckle/debug-print/compare/v0.2.0.0...v0.2.0.1)
 
 Relax lower dependency bounds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-## [_Unreleased_](https://github.com/freckle/debug-print/compare/v0.2.0.1...main)
+## [_Unreleased_](https://github.com/freckle/debug-print/compare/v0.2.1.0...main)
+
+## [v0.2.1.0](https://github.com/freckle/debug-print/compare/v0.2.0.1...v0.2.1.0)
+
+Add instances for `aeson` types:
+
+- `instance ToDebugPrintValue Key`
+- `instance ToDebugPrintValue Value`
+- `instance ToDebugPrintValue Object`
+- `instance ToDebugPrintRecord Object`
 
 ## [v0.2.0.1](https://github.com/freckle/debug-print/compare/v0.2.0.0...v0.2.0.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Add instances for `aeson` types:
 - `instance ToDebugPrintValue Object`
 - `instance ToDebugPrintRecord Object`
 
+Adds `Eq` and `Ord` instances for `ToDebugPrintValue` and `ToDebugPrintRecord`
+
 ## [v0.2.0.1](https://github.com/freckle/debug-print/compare/v0.2.0.0...v0.2.0.1)
 
 Relax lower dependency bounds

--- a/debug-print.cabal
+++ b/debug-print.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.0
 -- see: https://github.com/sol/hpack
 
 name:           debug-print
-version:        0.2.0.0
+version:        0.2.1.0
 synopsis:       A structured alternative to Show
 category:       Debug
 homepage:       https://github.com/freckle/debug-print#readme
@@ -41,6 +41,7 @@ library
       DefaultSignatures
       DeriveAnyClass
       DerivingVia
+      LambdaCase
       NoFieldSelectors
       NoImplicitPrelude
       NoMonomorphismRestriction
@@ -70,6 +71,7 @@ library internal
       DefaultSignatures
       DeriveAnyClass
       DerivingVia
+      LambdaCase
       NoFieldSelectors
       NoImplicitPrelude
       NoMonomorphismRestriction
@@ -77,8 +79,10 @@ library internal
       StrictData
   ghc-options: -Weverything -Wno-all-missed-specialisations -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-safe-haskell-mode -Wno-safe -Wno-unsafe
   build-depends:
-      base <5
+      aeson
+    , base <5
     , containers
+    , scientific
     , text
     , vector
   default-language: GHC2021
@@ -96,6 +100,7 @@ test-suite readme
       DefaultSignatures
       DeriveAnyClass
       DerivingVia
+      LambdaCase
       NoFieldSelectors
       NoImplicitPrelude
       NoMonomorphismRestriction
@@ -126,6 +131,7 @@ test-suite spec
       DefaultSignatures
       DeriveAnyClass
       DerivingVia
+      LambdaCase
       NoFieldSelectors
       NoImplicitPrelude
       NoMonomorphismRestriction

--- a/internal/DebugPrint/Core.hs
+++ b/internal/DebugPrint/Core.hs
@@ -33,7 +33,7 @@ import GHC.Generics
 import Numeric.Natural (Natural)
 
 newtype DebugPrintRecord = DebugPrintRecord (Map Text DebugPrintValue)
-  deriving newtype (Monoid, Semigroup)
+  deriving newtype (Eq, Monoid, Ord, Semigroup)
 
 data DebugPrintValue
   = DebugPrintValueInt Integer
@@ -41,6 +41,7 @@ data DebugPrintValue
   | DebugPrintValueBool Bool
   | DebugPrintValueVector (Vector DebugPrintValue)
   | DebugPrintValueRecord DebugPrintRecord
+  deriving stock (Eq, Ord)
 
 instance IsString DebugPrintValue where
   fromString = DebugPrintValueText . T.pack

--- a/internal/DebugPrint/Core.hs
+++ b/internal/DebugPrint/Core.hs
@@ -11,12 +11,16 @@ module DebugPrint.Core
 
 import Prelude
 
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Aeson.Key
+import Data.Aeson.KeyMap qualified as Aeson.KeyMap
 import Data.Foldable (toList)
 import Data.Int
 import Data.Kind (Type)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
 import Data.Map.Strict qualified as Map
+import Data.Scientific qualified as Scientific
 import Data.Sequence (Seq)
 import Data.String (IsString (..))
 import Data.Text (Text)
@@ -94,6 +98,27 @@ instance ToDebugPrintValue a => ToDebugPrintValue (Seq a) where
 instance ToDebugPrintValue a => ToDebugPrintValue (Vector a) where
   toDebugPrintValue = DebugPrintValueVector . fmap toDebugPrintValue
 
+instance ToDebugPrintValue Aeson.Key where
+  toDebugPrintValue = DebugPrintValueText . Aeson.Key.toText
+
+instance ToDebugPrintValue Aeson.Value where
+  toDebugPrintValue = \case
+    Aeson.Object x -> DebugPrintValueRecord $ toDebugPrintRecord x
+    Aeson.Array x -> DebugPrintValueVector $ fmap toDebugPrintValue x
+    Aeson.String x -> DebugPrintValueText $ T.unwords ["(string)", x]
+    Aeson.Number x ->
+      -- Since JSON numbers support scientific notation, an exponential form may
+      -- represent an unreasonably large integer. Int64 is an arbitrary limit on
+      -- the size of integer we're willing to expand.
+      case Scientific.toBoundedInteger @Int64 x of
+        Just i -> DebugPrintValueInt $ toInteger i
+        Nothing -> DebugPrintValueText $ T.unwords ["(number)", T.pack $ show x]
+    Aeson.Bool x -> DebugPrintValueBool x
+    Aeson.Null -> DebugPrintValueText "(null)"
+
+instance ToDebugPrintValue Aeson.Object where
+  toDebugPrintValue = DebugPrintValueRecord . toDebugPrintRecord
+
 ---
 
 class ToDebugPrintRecord a where
@@ -104,6 +129,9 @@ class ToDebugPrintRecord a where
 
 instance ToDebugPrintRecord DebugPrintRecord where
   toDebugPrintRecord = id
+
+instance ToDebugPrintRecord Aeson.Object where
+  toDebugPrintRecord = DebugPrintRecord . fmap toDebugPrintValue . Aeson.KeyMap.toMapText
 
 ---
 

--- a/internal/DebugPrint/Core.hs
+++ b/internal/DebugPrint/Core.hs
@@ -57,6 +57,9 @@ class ToDebugPrintValue a where
 instance ToDebugPrintValue DebugPrintValue where
   toDebugPrintValue = id
 
+instance ToDebugPrintValue DebugPrintRecord where
+  toDebugPrintValue = DebugPrintValueRecord
+
 instance ToDebugPrintValue Integer where
   toDebugPrintValue = DebugPrintValueInt
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: debug-print
-version: 0.2.0.1
+version: 0.2.1.0
 maintainer: Freckle Education
 category: Debug
 github: freckle/debug-print
@@ -34,6 +34,7 @@ default-extensions:
   - DefaultSignatures
   - DeriveAnyClass
   - DerivingVia
+  - LambdaCase
   - NoFieldSelectors
   - NoImplicitPrelude
   - NoMonomorphismRestriction
@@ -52,7 +53,9 @@ internal-libraries:
   internal:
     source-dirs: internal
     dependencies:
+      - aeson
       - containers
+      - scientific
       - text
       - vector
 


### PR DESCRIPTION
This adds debug print instances for Aeson types. The debug print format defined by this package is a simplified analog to JSON, so some adaptation is required to generally coerce JSON values into DebugPrintValue values.
- Objects, arrays, booleans, and small integers convert in a straightforward manner.
- Strings, numbers that involve decimals or exotically large magnitude expressed with scientific notation, and null are converted into a string, prefixed by an indication of what the JSON type was. (Reminder, the purpose of this package is to display values in an unambiguous and reasonably compact way.)

Added a few other minor instances as well, see changelog.